### PR TITLE
dev deploy use the same safer pattern deploy-dev.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,9 +20,15 @@ jobs:
         with:
           node-version: 20
           cache: npm
-
+          
       - name: Install dependencies
-        run: npm ci
+        run: |
+          if [ -f package.json ]; then
+            echo "Trying npm ci (strict install)..."
+            npm ci || (echo "npm ci failed, falling back to npm install" && npm install)
+          else
+            echo "no package.json"
+          fi
 
       - name: Build app
         run: npm run build


### PR DESCRIPTION
dev deploy use the same safer pattern
  - name: Install dependencies run: | if [ -f package.json ]; then echo "Trying npm ci (strict install)..." npm ci || (echo "npm ci failed, falling back to npm install" && npm install) else echo "no package.json" fi

## What
## Why
## How to test
- [ ] Unit tests updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] No secrets committed
